### PR TITLE
Modify "re usage" to "resuse"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 Pool is a thread safe connection pool for net.Conn interface. It can be used
-to manage and re usage connections.
+to manage and reuse connections.
 
 ## Install
 


### PR DESCRIPTION
"Reuse" is conform to grammar, and better than "re usage".
