### PR TITLE
add MarkUnreusable to pooled connection

### DIFF
--- a/channel_test.go
+++ b/channel_test.go
@@ -40,7 +40,7 @@ func TestPool_Get_Impl(t *testing.T) {
 		t.Errorf("Get error: %s", err)
 	}
 
-	_, ok := conn.(poolConn)
+	_, ok := conn.(*PoolConn)
 	if !ok {
 		t.Errorf("Conn is not of type poolConn")
 	}
@@ -116,6 +116,33 @@ func TestPool_Put(t *testing.T) {
 	conn.Close() // try to put into a full pool
 	if p.Len() != 0 {
 		t.Errorf("Put error. Closed pool shouldn't allow to put connections.")
+	}
+}
+
+func TestPool_PutUnreusableConn(t *testing.T) {
+	p, _ := newChannelPool()
+	defer p.Close()
+
+	// ensure pool is not empty
+	conn, _ := p.Get()
+	conn.Close()
+
+	poolSize := p.Len()
+	conn, _ = p.Get()
+	conn.Close()
+	if p.Len() != poolSize {
+		t.Errorf("Pool size is expected to be equal to initial size")
+	}
+
+	conn, _ = p.Get()
+	if pc, ok := conn.(*PoolConn); !ok {
+		t.Errorf("impossible")
+	} else {
+		pc.MarkUnreusable()
+	}
+	conn.Close()
+	if p.Len() != poolSize-1 {
+		t.Errorf("Pool size is expected to be initial_size - 1", p.Len(), poolSize-1)
 	}
 }
 

--- a/channel_test.go
+++ b/channel_test.go
@@ -119,7 +119,7 @@ func TestPool_Put(t *testing.T) {
 	}
 }
 
-func TestPool_PutUnreusableConn(t *testing.T) {
+func TestPool_PutUnusableConn(t *testing.T) {
 	p, _ := newChannelPool()
 	defer p.Close()
 
@@ -138,7 +138,7 @@ func TestPool_PutUnreusableConn(t *testing.T) {
 	if pc, ok := conn.(*PoolConn); !ok {
 		t.Errorf("impossible")
 	} else {
-		pc.MarkUnreusable()
+		pc.MarkUnusable()
 	}
 	conn.Close()
 	if p.Len() != poolSize-1 {

--- a/conn.go
+++ b/conn.go
@@ -2,21 +2,33 @@ package pool
 
 import "net"
 
-// poolConn is a wrapper around net.Conn to modify the the behavior of
+// PoolConn is a wrapper around net.Conn to modify the the behavior of
 // net.Conn's Close() method.
-type poolConn struct {
+type PoolConn struct {
 	net.Conn
-	c *channelPool
+	c          *channelPool
+	unreusable bool
 }
 
 // Close() puts the given connects back to the pool instead of closing it.
-func (p poolConn) Close() error {
+func (p PoolConn) Close() error {
+	if p.unreusable {
+		if p.Conn != nil {
+			p.Conn.Close()
+		}
+		return nil
+	}
 	return p.c.put(p.Conn)
+}
+
+// MarkUnreusable() marks the connection is not reusable.
+func (p *PoolConn) MarkUnreusable() {
+	p.unreusable = true
 }
 
 // newConn wraps a standard net.Conn to a poolConn net.Conn.
 func (c *channelPool) wrapConn(conn net.Conn) net.Conn {
-	p := poolConn{c: c}
+	p := &PoolConn{c: c}
 	p.Conn = conn
 	return p
 }

--- a/conn.go
+++ b/conn.go
@@ -7,12 +7,12 @@ import "net"
 type PoolConn struct {
 	net.Conn
 	c          *channelPool
-	unreusable bool
+	unusable bool
 }
 
 // Close() puts the given connects back to the pool instead of closing it.
 func (p PoolConn) Close() error {
-	if p.unreusable {
+	if p.unusable {
 		if p.Conn != nil {
 			p.Conn.Close()
 		}
@@ -22,8 +22,8 @@ func (p PoolConn) Close() error {
 }
 
 // MarkUnreusable() marks the connection is not reusable.
-func (p *PoolConn) MarkUnreusable() {
-	p.unreusable = true
+func (p *PoolConn) MarkUnusable() {
+	p.unusable = true
 }
 
 // newConn wraps a standard net.Conn to a poolConn net.Conn.

--- a/conn.go
+++ b/conn.go
@@ -21,7 +21,7 @@ func (p PoolConn) Close() error {
 	return p.c.put(p.Conn)
 }
 
-// MarkUnreusable() marks the connection is not reusable.
+// MarkUnusable() marks the connection not usable any more, to let the pool close it instead of returning it to pool.
 func (p *PoolConn) MarkUnusable() {
 	p.unusable = true
 }

--- a/conn.go
+++ b/conn.go
@@ -14,7 +14,7 @@ type PoolConn struct {
 func (p PoolConn) Close() error {
 	if p.unusable {
 		if p.Conn != nil {
-			p.Conn.Close()
+			return p.Conn.Close()
 		}
 		return nil
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -6,5 +6,5 @@ import (
 )
 
 func TestConn_Impl(t *testing.T) {
-	var _ net.Conn = new(poolConn)
+	var _ net.Conn = new(PoolConn)
 }


### PR DESCRIPTION
It's desirable to close the connection directly because an error, for example timeout, occurred on the connection. 

conn, err := pool.Get()
defer conn.Close()

if err := UseConn(conn); err != nil {
    conn.MarkUnreusable()
}

 This patch adds this feature.