### PR TITLE
Switch PoolConn.Close method to have a pointer receiver

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -6,12 +6,12 @@ import "net"
 // net.Conn's Close() method.
 type PoolConn struct {
 	net.Conn
-	c          *channelPool
+	c        *channelPool
 	unusable bool
 }
 
 // Close() puts the given connects back to the pool instead of closing it.
-func (p PoolConn) Close() error {
+func (p *PoolConn) Close() error {
 	if p.unusable {
 		if p.Conn != nil {
 			return p.Conn.Close()


### PR DESCRIPTION
The current implementation causes MarkUnusable to not work when using
`defer` on a pooled connection. A call to `defer conn.Close()` will
cause the connection to be copied before it has been marked unusable. If
tyou then call `MarkUnusable()` later in the function, it will not be
seen by the deferred close.

This is a nasty expectation for a user who is using standard Go
practices as most people expect that the method would have a pointer
receiver rather than a value receiver and would not expect the
connection to be copied when calling `defer`.