### PR TITLE
Add active connection limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,22 @@ p.Close()
 // currently available connections in the pool
 current := p.Len()
 ```
+## Example (active connection limit)
+```go
 
+// create a new channel based pool with an initial capacity of 5, maximum
+// capacity of 30 and a limit of 40. The factory will create 5 initial connections
+// and put it into the pool.
+p, err := pool.NewChannelPoolMaxActive(5, 30, 40, factory)
+
+// now you can get a connection from the pool, if there is no connection
+// available and you haven't reached the limit (40) it will create a new one 
+// via the factory function, otherwise it blocks until there is an available connection.
+conn, err := p.Get()
+
+// currently active connections in the pool
+actives := p.LenActives()
+```
 
 ## Credits
 

--- a/channel.go
+++ b/channel.go
@@ -13,6 +13,10 @@ type channelPool struct {
 	mu    sync.Mutex
 	conns chan net.Conn
 
+	// active connections limiter
+	isLimited bool
+	actives   chan struct{}
+
 	// net.Conn generator
 	factory Factory
 }
@@ -25,9 +29,10 @@ type Factory func() (net.Conn, error)
 // greater than zero to fill the pool. A zero initialCap doesn't fill the Pool
 // until a new Get() is called. During a Get(), If there is no new connection
 // available in the pool, a new connection will be created via the Factory()
-// method.
-func NewChannelPool(initialCap, maxCap int, factory Factory) (Pool, error) {
-	if initialCap < 0 || maxCap <= 0 || initialCap > maxCap {
+// method (unless maxActive > 0, i.e. there is a limit for active connections).
+func NewChannelPoolMaxActive(initialCap, maxCap int, maxActive int, factory Factory) (Pool, error) {
+	if initialCap < 0 || maxCap <= 0 || maxActive < 0 || initialCap > maxCap ||
+		(maxActive > 0 && maxActive < maxCap) {
 		return nil, errors.New("invalid capacity settings")
 	}
 
@@ -35,11 +40,15 @@ func NewChannelPool(initialCap, maxCap int, factory Factory) (Pool, error) {
 		conns:   make(chan net.Conn, maxCap),
 		factory: factory,
 	}
+	if maxActive > 0 {
+		c.isLimited = true
+		c.actives = make(chan struct{}, maxActive)
+	}
 
 	// create initial connections, if something goes wrong,
 	// just close the pool error out.
 	for i := 0; i < initialCap; i++ {
-		conn, err := factory()
+		conn, err := c.tryOpen()
 		if err != nil {
 			c.Close()
 			return nil, fmt.Errorf("factory is not able to fill the pool: %s", err)
@@ -50,11 +59,45 @@ func NewChannelPool(initialCap, maxCap int, factory Factory) (Pool, error) {
 	return c, nil
 }
 
+func NewChannelPool(initialCap, maxCap int, factory Factory) (Pool, error) {
+	return NewChannelPoolMaxActive(initialCap, maxCap, 0, factory)
+}
+
+func (c *channelPool) tryOpen() (net.Conn, error) {
+	// this will block if active connections are limited.
+	if c.isLimited {
+		c.actives <- struct{}{}
+	}
+	conn, err := c.factory()
+	if err != nil {
+		c.tryClose(conn)
+	}
+	return conn, err
+}
+
+func (c *channelPool) tryClose(conn net.Conn) error {
+	// update active connection limit.
+	if c.isLimited {
+		<-c.actives
+	}
+	if conn != nil {
+		return conn.Close()
+	}
+	return nil
+}
+
 func (c *channelPool) getConns() chan net.Conn {
 	c.mu.Lock()
 	conns := c.conns
 	c.mu.Unlock()
 	return conns
+}
+
+func (c *channelPool) getActives() chan struct{} {
+	c.mu.Lock()
+	actives := c.actives
+	c.mu.Unlock()
+	return actives
 }
 
 // Get implements the Pool interfaces Get() method. If there is no new
@@ -76,7 +119,7 @@ func (c *channelPool) Get() (net.Conn, error) {
 
 		return c.wrapConn(conn), nil
 	default:
-		conn, err := c.factory()
+		conn, err := c.tryOpen()
 		if err != nil {
 			return nil, err
 		}
@@ -107,14 +150,16 @@ func (c *channelPool) put(conn net.Conn) error {
 		return nil
 	default:
 		// pool is full, close passed connection
-		return conn.Close()
+		return c.tryClose(conn)
 	}
 }
 
 func (c *channelPool) Close() {
 	c.mu.Lock()
 	conns := c.conns
+	actives := c.actives
 	c.conns = nil
+	c.actives = nil
 	c.factory = nil
 	c.mu.Unlock()
 
@@ -126,6 +171,12 @@ func (c *channelPool) Close() {
 	for conn := range conns {
 		conn.Close()
 	}
+	if c.isLimited {
+		close(actives)
+		for _ = range actives {
+		}
+	}
 }
 
-func (c *channelPool) Len() int { return len(c.getConns()) }
+func (c *channelPool) Len() int        { return len(c.getConns()) }
+func (c *channelPool) LenActives() int { return len(c.getActives()) }

--- a/conn.go
+++ b/conn.go
@@ -20,10 +20,7 @@ func (p *PoolConn) Close() error {
 	defer p.mu.RUnlock()
 
 	if p.unusable {
-		if p.Conn != nil {
-			return p.Conn.Close()
-		}
-		return nil
+		return p.c.tryClose(p.Conn)
 	}
 	return p.c.put(p.Conn)
 }

--- a/conn.go
+++ b/conn.go
@@ -16,6 +16,7 @@ type PoolConn struct {
 
 func (p *PoolConn) Read(b []byte) (int, error) {
 	n, err := p.Conn.Read(b)
+	// mark as unusable on error.
 	if terr, ok := err.(net.Error); ok && !terr.Timeout() {
 		p.MarkUnusable()
 	}
@@ -24,6 +25,7 @@ func (p *PoolConn) Read(b []byte) (int, error) {
 
 func (p *PoolConn) Write(b []byte) (int, error) {
 	n, err := p.Conn.Write(b)
+	// mark as unusable on error.
 	if terr, ok := err.(net.Error); ok && !terr.Timeout() {
 		p.MarkUnusable()
 	}

--- a/conn.go
+++ b/conn.go
@@ -14,6 +14,22 @@ type PoolConn struct {
 	unusable bool
 }
 
+func (p *PoolConn) Read(b []byte) (int, error) {
+	n, err := p.Conn.Read(b)
+	if terr, ok := err.(net.Error); ok && !terr.Timeout() {
+		p.MarkUnusable()
+	}
+	return n, err
+}
+
+func (p *PoolConn) Write(b []byte) (int, error) {
+	n, err := p.Conn.Write(b)
+	if terr, ok := err.(net.Error); ok && !terr.Timeout() {
+		p.MarkUnusable()
+	}
+	return n, err
+}
+
 // Close() puts the given connects back to the pool instead of closing it.
 func (p *PoolConn) Close() error {
 	p.mu.RLock()

--- a/pool.go
+++ b/pool.go
@@ -25,4 +25,7 @@ type Pool interface {
 
 	// Len returns the current number of connections of the pool.
 	Len() int
+
+	// Returns total active connections.
+	LenActives() int
 }

--- a/pool.go
+++ b/pool.go
@@ -9,6 +9,8 @@ import (
 var (
 	// ErrClosed is the error resulting if the pool is closed via pool.Close().
 	ErrClosed = errors.New("pool is closed")
+	// This is the error resulting if the active connection limit is reached.
+	ErrConnLimit = errors.New("connection limit reached")
 )
 
 // Pool interface describes a pool implementation. A pool should have maximum
@@ -17,7 +19,13 @@ type Pool interface {
 	// Get returns a new connection from the pool. Closing the connections puts
 	// it back to the Pool. Closing it when the pool is destroyed or full will
 	// be counted as an error.
+	// Setting an active connection limit will cause this function to block if
+	// the limit is reached (use TryGet() to avoid blocking).
 	Get() (net.Conn, error)
+
+	// Behaves like Get() but will return ErrConnLimit instead of blocking when
+	// the active connection limit is reached.
+	TryGet() (net.Conn, error)
 
 	// Close closes the pool and all its connections. After Close() the pool is
 	// no longer usable.


### PR DESCRIPTION
Please review these changes.
 - Will limit the number of active/created connections. So, when you hit the limit `Get()` will block until there is an available/idle connection in the pool.
 - Add a new function `TryGet()` to return an error instead of blocking when you hit the limit.
 - Update README with example code
 - Update Read/Write methods to `MarkUnusable()` on errors.