### PR TITLE
Update readme about closing underlying connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ conn, err := p.Get()
 // to the pool).
 conn.Close()
 
+// close the underlying connection instead of returning it to pool
+// it is useful when acceptor has already closed connection and conn.Write() returns error
+if pc, ok := conn.(*pool.PoolConn); ok {
+  pc.MarkUnusable()
+  pc.Close()
+}
+
 // close pool any time you want, this closes all the connections inside a pool
 p.Close()
 


### PR DESCRIPTION
The current README describes only the way of putting the connection back to the pool.
But there is a case that acceptor closes connection and (net.Conn)Write returns error so you'd like to close the underlying connection.