### PR TITLE
Add Supply function with required connection number

### DIFF
--- a/channel_test.go
+++ b/channel_test.go
@@ -142,7 +142,7 @@ func TestPool_PutUnusableConn(t *testing.T) {
 	}
 	conn.Close()
 	if p.Len() != poolSize-1 {
-		t.Errorf("Pool size is expected to be initial_size - 1", p.Len(), poolSize-1)
+		t.Errorf("Pool size is expected to be initial_size - 1. Expecting %d, got %d", poolSize-1, p.Len())
 	}
 }
 
@@ -247,6 +247,33 @@ func TestPoolConcurrent2(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestPoolSupply(t *testing.T) {
+	p, _ := NewChannelPool(0, 5, factory)
+	err := p.Supply(1)
+	if err != nil {
+		t.Error(err)
+	}
+	if p.Len() != 1 {
+		t.Errorf("Pool size is expected to be 1, got %d", p.Len())
+	}
+
+	err = p.Supply(6)
+	if err != nil {
+		t.Error(err)
+	}
+	if p.Len() != 5 {
+		t.Errorf("Pool size is expected to be 5, got %d", p.Len())
+	}
+
+	err = p.Supply(2)
+	if err != nil {
+		t.Error(err)
+	}
+	if p.Len() != 5 {
+		t.Errorf("Pool size is expected to be 5, got %d", p.Len())
+	}
 }
 
 func newChannelPool() (Pool, error) {

--- a/pool.go
+++ b/pool.go
@@ -19,6 +19,9 @@ type Pool interface {
 	// be counted as an error.
 	Get() (net.Conn, error)
 
+	// Supply connections to the pool at most the cap of channel buffer.
+	Supply(int) error
+
 	// Close closes the pool and all its connections. After Close() the pool is
 	// no longer usable.
 	Close()


### PR DESCRIPTION
Add `Supply` function to `Pool` interface.

**Why**
I'd like to add new tcp connection to the pool.
In my case, I'm using NLB which AWS released the other day for load balancing tcp requests.
When sending original protocol data on tcp stream, initiator has to make some connection to distribute the requests.
Accoding to the current code, what `Get()` do is that fetching connection from the pool and if when there is no connection in the pool, launch new connection and put it to the pool.
So I want a function to maintain some connection in the pool.